### PR TITLE
Prevent using quoted brackets in frameworks

### DIFF
--- a/PermissionsKit.xcodeproj/project.pbxproj
+++ b/PermissionsKit.xcodeproj/project.pbxproj
@@ -619,6 +619,7 @@
 		A706EB67214938530098836A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -645,6 +646,7 @@
 		A706EB68214938530098836A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -672,6 +674,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = S8EX82NJP6;
@@ -690,6 +693,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = S8EX82NJP6;

--- a/PermissionsKit/PermissionsKit.h
+++ b/PermissionsKit/PermissionsKit.h
@@ -11,6 +11,6 @@
 FOUNDATION_EXPORT double PermissionsKitVersionNumber;
 FOUNDATION_EXPORT const unsigned char PermissionsKitVersionString[];
 
-#import "MPAuthorizationStatus.h"
-#import "MPPermissionType.h"
-#import "MPPermissionsKit.h"
+#import <PermissionsKit/MPAuthorizationStatus.h>
+#import <PermissionsKit/MPPermissionType.h>
+#import <PermissionsKit/MPPermissionsKit.h>

--- a/PermissionsKit/Public/MPPermissionsKit.h
+++ b/PermissionsKit/Public/MPPermissionsKit.h
@@ -8,8 +8,8 @@
 
 @import Foundation;
 
-#import "MPPermissionType.h"
-#import "MPAuthorizationStatus.h"
+#import <PermissionsKit/MPPermissionType.h>
+#import <PermissionsKit/MPAuthorizationStatus.h>
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
Adding CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER warning
Fixing all cases when quoted include is used inside the framework