### PR TITLE
Remove incorrect string encoding warning

### DIFF
--- a/PermissionsKit/Private/FullDiskAccess/MPFullDiskAccessAuthorizer.m
+++ b/PermissionsKit/Private/FullDiskAccess/MPFullDiskAccessAuthorizer.m
@@ -66,7 +66,7 @@
 
 - (MPAuthorizationStatus)_checkFDAUsingFile:(NSString *)path
 {
-    int fd = open([path cStringUsingEncoding:kCFStringEncodingUTF8], O_RDONLY);
+    int fd = open([path cStringUsingEncoding:NSUTF8StringEncoding], O_RDONLY);
     if (fd != -1)
     {
         close(fd);


### PR DESCRIPTION
# What
Removed warning about incorrect string encoding usage.
```
Incorrect NSStringEncoding value 0x8000100 detected. Assuming NSStringEncodingASCII. Will stop this compatibility mapping behavior in the near future.
```