### PR TITLE
lift the min target version so that can be compiled on 13.5

### DIFF
--- a/PermissionsKit.xcodeproj/project.pbxproj
+++ b/PermissionsKit.xcodeproj/project.pbxproj
@@ -640,7 +640,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.macpaw.PermissionsKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -668,7 +668,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.macpaw.PermissionsKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
In the latest stable macOS 13.5, archive error shows: `ld: file not found: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/arc/libarclite_macosx.a`

It was bcs `libarclite_macosx.a` was necessary for older macOS versions but is now obsolete, lifting the min target version to 10.11 fixes this. 

ref: https://developer.apple.com/forums/thread/728021