### PR TITLE
Fixed Full Disk Access always returns an authorized status by TCC.db.

### DIFF
--- a/PermissionsKit/Private/FullDiskAccess/MPFullDiskAccessAuthorizer.m
+++ b/PermissionsKit/Private/FullDiskAccess/MPFullDiskAccessAuthorizer.m
@@ -91,7 +91,7 @@
     NSArray<NSString *> *testFiles = @[
         [self.userHomeFolderPath stringByAppendingPathComponent:@"Library/Safari/CloudTabs.db"],
         [self.userHomeFolderPath stringByAppendingPathComponent:@"Library/Safari/Bookmarks.plist"],
-        [self.userHomeFolderPath stringByAppendingPathComponent: @"/Library/Application Support/com.apple.TCC/TCC.db"],
+        [self.userHomeFolderPath stringByAppendingPathComponent: @"Library/Application Support/com.apple.TCC/TCC.db"],
         @"/Library/Preferences/com.apple.TimeMachine.plist",
     ];
     

--- a/PermissionsKit/Private/FullDiskAccess/MPFullDiskAccessAuthorizer.m
+++ b/PermissionsKit/Private/FullDiskAccess/MPFullDiskAccessAuthorizer.m
@@ -91,7 +91,7 @@
     NSArray<NSString *> *testFiles = @[
         [self.userHomeFolderPath stringByAppendingPathComponent:@"Library/Safari/CloudTabs.db"],
         [self.userHomeFolderPath stringByAppendingPathComponent:@"Library/Safari/Bookmarks.plist"],
-        @"/Library/Application Support/com.apple.TCC/TCC.db",
+        [self.userHomeFolderPath stringByAppendingPathComponent: @"/Library/Application Support/com.apple.TCC/TCC.db"],
         @"/Library/Preferences/com.apple.TimeMachine.plist",
     ];
     


### PR DESCRIPTION
### Motivation
I faced the issue on macOS Sonoma 14.4.1: Full Disk Access always returns an `authorized` status by TCC.db. This [issue](https://github.com/MacPaw/PermissionsKit/issues/23) has occurred before. 

![CleanShot 2024-04-09 at 17 46 58@2x](https://github.com/MacPaw/PermissionsKit/assets/128129514/9ecb969c-2010-4caa-914f-a77e41e0d3b8)

### Solution
There are several TCC.db in the system: 

1. The system-wide database in `/Library/Application Support/com.apple.TCC/TCC.db`
 This database is SIP protected, so only a SIP bypass can write into it.
2. The user TCC database in `$HOME/Library/Application Support/com.apple.TCC/TCC.db` for per-user preferences.
This database is protected so only processes with high TCC privileges like Full Disk Access can write to it (but it's not protected by SIP).

So in this case we can use the user's TCC database to check the FDA status.

![CleanShot 2024-04-10 at 15 20 54@2x](https://github.com/MacPaw/PermissionsKit/assets/128129514/6797acfa-2327-4d43-adb1-d0f6c102b28f)

### Info
Lately, there have been renewed complaints about this [issue](https://forums.developer.apple.com/forums/thread/114452?page=2) on the Apple developer forum.
Also see [macOS TCC Information](https://book.hacktricks.xyz/macos-hardening/macos-security-and-privilege-escalation/macos-security-protections/macos-tcc)