### PR TITLE
Bugfix/handle write only authorization status

### DIFF
--- a/PermissionsKit/Private/Calendar/MPCalendarAuthorizer.m
+++ b/PermissionsKit/Private/Calendar/MPCalendarAuthorizer.m
@@ -66,6 +66,8 @@
             return MPAuthorizationStatusAuthorized;
         case EKAuthorizationStatusNotDetermined:
             return MPAuthorizationStatusNotDetermined;
+        case EKAuthorizationStatusWriteOnly:
+            return MPAuthorizationStatusDenied;
     }
 }
 

--- a/PermissionsKit/Private/Calendar/MPCalendarAuthorizer.m
+++ b/PermissionsKit/Private/Calendar/MPCalendarAuthorizer.m
@@ -65,9 +65,8 @@
         case EKAuthorizationStatusAuthorized:
             return MPAuthorizationStatusAuthorized;
         case EKAuthorizationStatusNotDetermined:
-            return MPAuthorizationStatusNotDetermined;
         case EKAuthorizationStatusWriteOnly:
-            return MPAuthorizationStatusDenied;
+            return MPAuthorizationStatusNotDetermined;
     }
 }
 


### PR DESCRIPTION
### Motivation
The project does not compile due to missing switch cases `EKAuthorizationStatus.EKAuthorizationStatusWriteOnly`.


![CleanShot 2024-04-12 at 10 46 59@2x](https://github.com/MacPaw/PermissionsKit/assets/128129514/0090c311-a802-440d-afe7-9e5d329b6971)
![CleanShot 2024-04-12 at 10 50 19@2x](https://github.com/MacPaw/PermissionsKit/assets/128129514/3cd2095e-f182-42bf-97c8-e34d6b4ef01c)

