### PR TITLE
Add support for SPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 # Xcode
+
+
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
@@ -61,5 +63,11 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+#
+.build/
 
 .DS_Store

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "PermissionsKit",
+    platforms: [
+        .macOS(.v10_13)
+    ],
+    products: [
+        .library(
+            name: "PermissionsKit",
+            targets: ["PermissionsKit"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "PermissionsKit",
+            path: "PermissionsKit",
+            sources: [
+                "Public",
+                "Private"
+            ],
+            linkerSettings: [
+                .linkedFramework("Cocoa"),
+                .linkedFramework("Contacts"),
+                .linkedFramework("EventKit"),
+                .linkedFramework("Photos")
+            ]
+        )
+    ]
+) 

--- a/PermissionsKit-macOS.podspec
+++ b/PermissionsKit-macOS.podspec
@@ -17,7 +17,7 @@ The convenient wrapper on macOS permissions API. You can check and request user 
   s.osx.deployment_target = "10.13"
 
   s.source_files = 'PermissionsKit/Public/**/*', 'PermissionsKit/Private/**/*', 'PermissionsKit/PermissionsKit.h'
-
+  s.exclude_files = "PermissionsKit/include/**"
   s.public_header_files = 'PermissionsKit/Public/**/*.h', 'PermissionsKit/PermissionsKit.h'
   s.frameworks = 'Cocoa', 'Contacts', 'EventKit', 'Photos'
 end

--- a/PermissionsKit/Public/MPAuthorizationStatus.h
+++ b/PermissionsKit/Public/MPAuthorizationStatus.h
@@ -6,6 +6,8 @@
 //  Copyright © 2018 MacPaw. All rights reserved.
 //
 
+@import Foundation;
+
 typedef NS_ENUM(NSUInteger, MPAuthorizationStatus) {
     MPAuthorizationStatusNotDetermined,
     MPAuthorizationStatusDenied,

--- a/PermissionsKit/Public/MPPermissionType.h
+++ b/PermissionsKit/Public/MPPermissionType.h
@@ -6,6 +6,8 @@
 //  Copyright © 2018 MacPaw. All rights reserved.
 //
 
+@import Foundation;
+
 typedef NS_ENUM(NSUInteger, MPPermissionType) {
     MPPermissionTypeCalendar = 0,
     MPPermissionTypeReminders,

--- a/PermissionsKit/Public/MPPermissionsKit.h
+++ b/PermissionsKit/Public/MPPermissionsKit.h
@@ -8,8 +8,8 @@
 
 @import Foundation;
 
-#import <PermissionsKit/MPPermissionType.h>
-#import <PermissionsKit/MPAuthorizationStatus.h>
+#import "MPPermissionType.h"
+#import "MPAuthorizationStatus.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/PermissionsKit/include/MPAuthorizationStatus.h
+++ b/PermissionsKit/include/MPAuthorizationStatus.h
@@ -1,0 +1,1 @@
+../Public/MPAuthorizationStatus.h

--- a/PermissionsKit/include/MPAuthorizer.h
+++ b/PermissionsKit/include/MPAuthorizer.h
@@ -1,0 +1,1 @@
+../Private/MPAuthorizer.h

--- a/PermissionsKit/include/MPCalendarAuthorizer.h
+++ b/PermissionsKit/include/MPCalendarAuthorizer.h
@@ -1,0 +1,1 @@
+../Private/Calendar/MPCalendarAuthorizer.h

--- a/PermissionsKit/include/MPContactsAuthorization.h
+++ b/PermissionsKit/include/MPContactsAuthorization.h
@@ -1,0 +1,1 @@
+../Private/Contacts/MPContactsAuthorization.h

--- a/PermissionsKit/include/MPContactsAuthorizer.h
+++ b/PermissionsKit/include/MPContactsAuthorizer.h
@@ -1,0 +1,1 @@
+../Private/Contacts/MPContactsAuthorizer.h

--- a/PermissionsKit/include/MPFullDiskAccessAuthorizer.h
+++ b/PermissionsKit/include/MPFullDiskAccessAuthorizer.h
@@ -1,0 +1,1 @@
+../Private/FullDiskAccess/MPFullDiskAccessAuthorizer.h

--- a/PermissionsKit/include/MPPermissionType.h
+++ b/PermissionsKit/include/MPPermissionType.h
@@ -1,0 +1,1 @@
+../Public/MPPermissionType.h

--- a/PermissionsKit/include/MPPermissionsKit.h
+++ b/PermissionsKit/include/MPPermissionsKit.h
@@ -1,0 +1,1 @@
+../Public/MPPermissionsKit.h

--- a/PermissionsKit/include/MPPhotosAuthorizer.h
+++ b/PermissionsKit/include/MPPhotosAuthorizer.h
@@ -1,0 +1,1 @@
+../Private/Photos/MPPhotosAuthorizer.h

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 [![CI Status](https://img.shields.io/travis/MacPaw/PermissionsKit.svg?style=flat)](https://travis-ci.org/MacPaw/PermissionsKit)
 [![Version](https://img.shields.io/cocoapods/v/PermissionsKit-macOS.svg?style=flat)](https://cocoapods.org/pods/PermissionsKit-macOS)
+[![Swift Package Manager](https://img.shields.io/badge/Swift%20Package%20Manager-compatible-brightgreen.svg)](https://github.com/apple/swift-package-manager)
 [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-FC6956.svg?style=flat)](https://github.com/MacPaw/PermissionsKit)
 [![Platform](https://img.shields.io/cocoapods/p/PermissionsKit-macOS.svg?style=flat)](https://cocoapods.org/pods/PermissionsKit-macOS)
 [![License](https://img.shields.io/cocoapods/l/PermissionsKit-macOS.svg?style=flat)](https://cocoapods.org/pods/PermissionsKit-macOS)
@@ -126,6 +127,19 @@ For more details please check [Full Disk Access](#full-disk-access) details.
 
 
 ## Installation
+
+### Swift Package Manager
+PermissionsKit supports SPM from Xcode 11.0+. To install it, simply add the package to your project using the following repository URL:
+```
+https://github.com/MacPaw/PermissionsKit.git
+```
+
+Or add it to your `Package.swift` file:
+```swift
+dependencies: [
+    .package(url: "https://github.com/MacPaw/PermissionsKit.git", from: "1.0.7")
+]
+```
 
 ### CocoaPods
 PermissionsKit is available through [CocoaPods](https://cocoapods.org). To install it, simply add the following line to your Podfile:


### PR DESCRIPTION

- [x] All headers are symlinked to /include directory, which is required by SPM
- [x] Imports now use either @import syntax or double-quoted syntax.
- [x] Readme instructions assume there will be a 3.0.7 release with this :)

Closes #31 